### PR TITLE
优化 地图组件卸载的时候把相关事件移除

### DIFF
--- a/web/src/pages/Edit/components/Navigator.vue
+++ b/web/src/pages/Edit/components/Navigator.vue
@@ -45,16 +45,28 @@ export default {
     };
   },
   mounted() {
-    this.$bus.$on("toggle_mini_map", (show) => {
+    this.$bus.$on("toggle_mini_map", this.toggle_mini_map);
+    this.$bus.$on("data_change", this.data_change);
+    this.$bus.$on("view_data_change", this.view_data_change);
+  },
+  destroyed() {
+    this.$bus.$off("toggle_mini_map", this.toggle_mini_map);
+    this.$bus.$off("data_change", this.data_change);
+    this.$bus.$off("view_data_change", this.view_data_change);
+  },
+  methods: {
+    toggle_mini_map(show) {
       this.showMiniMap = show;
       this.$nextTick(() => {
-        if (show) {
+        if (this.$refs.navigatorBox) {
           this.init();
+        }
+        if (this.$refs.svgBox) {
           this.drawMiniMap();
         }
       });
-    });
-    this.$bus.$on("data_change", () => {
+    },
+    data_change() {
       if (!this.showMiniMap) {
         return;
       }
@@ -62,8 +74,8 @@ export default {
       this.timer = setTimeout(() => {
         this.drawMiniMap();
       }, 500);
-    });
-    this.$bus.$on("view_data_change", () => {
+    },
+    view_data_change() {
       if (!this.showMiniMap) {
         return;
       }
@@ -71,9 +83,7 @@ export default {
       this.timer = setTimeout(() => {
         this.drawMiniMap();
       }, 500);
-    });
-  },
-  methods: {
+    },
     init() {
       let { width, height } = this.$refs.navigatorBox.getBoundingClientRect();
       this.boxWidth = width;


### PR DESCRIPTION
优化 地图组件卸载的时候把相关事件移除（比如防止在调用保存接口后重新渲染页面，会同时触发新的和旧的navigator事件，而旧的组件中dom节点以及没有挂载在当前页面下，会报错）