### PR TITLE
解决层级遮罩问题

### DIFF
--- a/web/src/pages/Edit/components/Contextmenu.vue
+++ b/web/src/pages/Edit/components/Contextmenu.vue
@@ -3,7 +3,7 @@
     class="contextmenuContainer listBox"
     v-if="isShow"
     ref="contextmenuRef"
-    :style="{ left: left + 'px', top: top + 'px' }"
+    :style="{ left: left + 'px', top: top + 'px', 'z-index': 3 }"
     :class="{ isDark: isDark }"
   >
     <template v-if="type === 'node'">


### PR DESCRIPTION
解决小屏幕下，右键菜单被工具栏遮挡问题
<img width="605" alt="image" src="https://github.com/wanglin2/mind-map/assets/16569274/e796f9f1-0db5-4c5c-979c-d515a2978a62">
