### PR TITLE
feat: 增加checkCustomEnterTextEdit是否进入节点编辑模式的拦截方法

### DIFF
--- a/simple-mind-map/src/constants/defaultOptions.js
+++ b/simple-mind-map/src/constants/defaultOptions.js
@@ -128,6 +128,8 @@ export const defaultOpt = {
   // 是否在存在一个激活节点时，当按下中文、英文、数字按键时自动进入文本编辑模式
   // 开启该特性后，需要给你的输入框绑定keydown事件，并禁止冒泡
   enableAutoEnterTextEditWhenKeydown: false,
+  // 启用enableAutoEnterTextEditWhenKeydown后，自己判断是否拦截输入框展示
+  checkCustomEnterTextEdit: null,
   // 自定义对剪贴板文本的处理。当按ctrl+v粘贴时会读取用户剪贴板中的文本和图片，默认只会判断文本是否是普通文本和simple-mind-map格式的节点数据，如果你想处理其他思维导图的数据，比如processon、zhixi等，那么可以传递一个函数，接受当前剪贴板中的文本为参数，返回处理后的数据，可以返回两种类型：
   /*
     1.返回一个纯文本，那么会直接以该文本创建一个子节点

--- a/simple-mind-map/src/core/render/TextEdit.js
+++ b/simple-mind-map/src/core/render/TextEdit.js
@@ -101,6 +101,10 @@ export default class TextEdit {
 
   // 按键事件
   onKeydown(e) {
+    // 检测外部传入的自定义是否进入编辑态拦截方法，有些情况阻止冒泡不管用
+    if (this.mindMap.opt.checkCustomEnterTextEdit && !this.mindMap.opt.checkCustomEnterTextEdit()) { 
+      return
+    };
     const activeNodeList = this.mindMap.renderer.activeNodeList
     if (activeNodeList.length <= 0 || activeNodeList.length > 1) return
     const node = activeNodeList[0]


### PR DESCRIPTION
#902 
开启enableAutoEnterTextEditWhenKeydown，自定义的input, textarea某些特殊情况下阻止冒泡没用(渲染，挂载等因素)，通过传入自定义的判断方法，控制性更强。