### PR TITLE
新增enableAutoEmptyTextWhenKeydown属性，单击节点键入清空原文本

### DIFF
--- a/simple-mind-map/src/constants/defaultOptions.js
+++ b/simple-mind-map/src/constants/defaultOptions.js
@@ -130,6 +130,8 @@ export const defaultOpt = {
   // 是否在存在一个激活节点时，当按下中文、英文、数字按键时自动进入文本编辑模式
   // 开启该特性后，需要给你的输入框绑定keydown事件，并禁止冒泡
   enableAutoEnterTextEditWhenKeydown: false,
+  // 是否在存在一个激活节点时，当按下中文、英文、数字按键时自动进入文本编辑模式，且节点文本清空
+  enableAutoEmptyTextWhenKeydown: false,
   // 自定义对剪贴板文本的处理。当按ctrl+v粘贴时会读取用户剪贴板中的文本和图片，默认只会判断文本是否是普通文本和simple-mind-map格式的节点数据，如果你想处理其他思维导图的数据，比如processon、zhixi等，那么可以传递一个函数，接受当前剪贴板中的文本为参数，返回处理后的数据，可以返回两种类型：
   /*
     1.返回一个纯文本，那么会直接以该文本创建一个子节点

--- a/simple-mind-map/src/core/render/TextEdit.js
+++ b/simple-mind-map/src/core/render/TextEdit.js
@@ -92,7 +92,7 @@ export default class TextEdit {
     })
     this.mindMap.on('scale', this.onScale)
     // // 监听按键事件，判断是否自动进入文本编辑模式
-    if (this.mindMap.opt.enableAutoEnterTextEditWhenKeydown || this.mindMap.opt.enableAutoEnterTextCoverWhenKeydown) {
+    if (this.mindMap.opt.enableAutoEnterTextEditWhenKeydown || this.mindMap.opt.enableAutoEmptyTextWhenKeydown) {
       window.addEventListener('keydown', this.onKeydown)
     }
     this.mindMap.on('beforeDestroy', () => {
@@ -115,20 +115,11 @@ export default class TextEdit {
       }
       if (
         opt.enableAutoEnterTextEditWhenKeydown !==
-        lastOpt.enableAutoEnterTextEditWhenKeydown
+        lastOpt.enableAutoEnterTextEditWhenKeydown || opt.enableAutoEmptyTextWhenKeydown !==
+        lastOpt.enableAutoEmptyTextWhenKeydown
       ) {
         window[
-          opt.enableAutoEnterTextEditWhenKeydown
-            ? 'addEventListener'
-            : 'removeEventListener'
-        ]('keydown', this.onKeydown)
-      }
-      if (
-        opt.enableAutoEnterTextCoverWhenKeydown !==
-        lastOpt.enableAutoEnterTextCoverWhenKeydown
-      ) {
-        window[
-          opt.enableAutoEnterTextCoverWhenKeydown
+          opt.enableAutoEnterTextEditWhenKeydown || opt.enableAutoEmptyTextWhenKeydown 
             ? 'addEventListener'
             : 'removeEventListener'
         ]('keydown', this.onKeydown)
@@ -245,8 +236,8 @@ export default class TextEdit {
     this.textEditNode.style.background = openRealtimeRenderOnNodeTextEdit
       ? 'transparent'
       : this.currentNode
-      ? this.getBackground(this.currentNode)
-      : ''
+        ? this.getBackground(this.currentNode)
+        : ''
     this.textEditNode.style.boxShadow = openRealtimeRenderOnNodeTextEdit
       ? 'none'
       : '0 0 20px rgba(0,0,0,.5)'
@@ -277,7 +268,8 @@ export default class TextEdit {
       nodeTextEditZIndex,
       textAutoWrapWidth,
       selectTextOnEnterEditText,
-      openRealtimeRenderOnNodeTextEdit
+      openRealtimeRenderOnNodeTextEdit,
+      enableAutoEmptyTextWhenKeydown
     } = this.mindMap.opt
     if (!isFromScale) {
       this.mindMap.emit('before_show_text_edit')
@@ -291,8 +283,8 @@ export default class TextEdit {
         box-sizing: border-box;
         ${
           openRealtimeRenderOnNodeTextEdit
-            ? ''
-            : `box-shadow: 0 0 20px rgba(0,0,0,.5);`
+          ? ''
+          : `box-shadow: 0 0 20px rgba(0,0,0,.5);`
         }
         padding: ${this.textNodePaddingY}px ${this.textNodePaddingX}px;
         margin-left: -${this.textNodePaddingX}px;
@@ -351,18 +343,8 @@ export default class TextEdit {
     }
     this.textEditNode.style.zIndex = nodeTextEditZIndex
     this.textEditNode.innerHTML = textLines.join('<br>')
-    if(this.mindMap.opt.enableAutoEnterTextCoverWhenKeydown){
+    if (enableAutoEmptyTextWhenKeydown && isFromKeyDown) {
       this.textEditNode.innerHTML = ''
-    }
-    if(this.mindMap.opt.enableAutoSelectAllTextWhenDoubleClick && isFromDbclick){
-      console.log('here')
-      this.textEditNode.innerHTML = textLines.join('<br>')
-      const selection = window.getSelection()
-      // selection.removeAllRanges()
-      const range = document.createRange()
-      range.selectNodeContents(this.textEditNode)
-      selection.addRange(range)
-      console.log('selection', selection)
     }
     this.textEditNode.style.minWidth =
       rect.width + this.textNodePaddingX * 2 + 'px'
@@ -375,7 +357,7 @@ export default class TextEdit {
       this.textEditNode.style.lineHeight = noneRichTextNodeLineHeight
       this.textEditNode.style.transform = `translateY(${
         (((noneRichTextNodeLineHeight - 1) * fontSize) / 2) * scale
-      }px)`
+        }px)`
     } else {
       this.textEditNode.style.lineHeight = 'normal'
     }

--- a/simple-mind-map/src/core/render/TextEdit.js
+++ b/simple-mind-map/src/core/render/TextEdit.js
@@ -43,7 +43,7 @@ export default class TextEdit {
     this.onKeydown = this.onKeydown.bind(this)
     // 节点双击事件
     this.mindMap.on('node_dblclick', (node, e, isInserting) => {
-      this.show({ node, e, isInserting, isFromDbclick: true })
+      this.show({ node, e, isInserting })
     })
     // 点击事件
     this.mindMap.on('draw_click', () => {
@@ -185,8 +185,6 @@ export default class TextEdit {
     node,
     isInserting = false,
     isFromKeyDown = false,
-    isFromScale = false,
-    isFromDbclick = false
   }) {
     // 使用了自定义节点内容那么不响应编辑事件
     if (node.isUseCustomNodeContent()) {
@@ -218,8 +216,6 @@ export default class TextEdit {
       rect,
       isInserting,
       isFromKeyDown,
-      isFromScale,
-      isFromDbclick
     }
     if (this.mindMap.richText) {
       this.mindMap.richText.showEditText(params)
@@ -236,8 +232,8 @@ export default class TextEdit {
     this.textEditNode.style.background = openRealtimeRenderOnNodeTextEdit
       ? 'transparent'
       : this.currentNode
-        ? this.getBackground(this.currentNode)
-        : ''
+      ? this.getBackground(this.currentNode)
+      : ''
     this.textEditNode.style.boxShadow = openRealtimeRenderOnNodeTextEdit
       ? 'none'
       : '0 0 20px rgba(0,0,0,.5)'
@@ -262,7 +258,7 @@ export default class TextEdit {
   }
 
   //  显示文本编辑框
-  showEditTextBox({ node, rect, isInserting, isFromKeyDown, isFromScale, isFromDbclick }) {
+  showEditTextBox({ node, rect, isInserting, isFromKeyDown, isFromScale }) {
     if (this.showTextEdit) return
     const {
       nodeTextEditZIndex,
@@ -283,8 +279,8 @@ export default class TextEdit {
         box-sizing: border-box;
         ${
           openRealtimeRenderOnNodeTextEdit
-          ? ''
-          : `box-shadow: 0 0 20px rgba(0,0,0,.5);`
+            ? ''
+            : `box-shadow: 0 0 20px rgba(0,0,0,.5);`
         }
         padding: ${this.textNodePaddingY}px ${this.textNodePaddingX}px;
         margin-left: -${this.textNodePaddingX}px;
@@ -357,7 +353,7 @@ export default class TextEdit {
       this.textEditNode.style.lineHeight = noneRichTextNodeLineHeight
       this.textEditNode.style.transform = `translateY(${
         (((noneRichTextNodeLineHeight - 1) * fontSize) / 2) * scale
-        }px)`
+      }px)`
     } else {
       this.textEditNode.style.lineHeight = 'normal'
     }

--- a/simple-mind-map/src/core/render/TextEdit.js
+++ b/simple-mind-map/src/core/render/TextEdit.js
@@ -185,6 +185,7 @@ export default class TextEdit {
     node,
     isInserting = false,
     isFromKeyDown = false,
+    isFromScale = false
   }) {
     // 使用了自定义节点内容那么不响应编辑事件
     if (node.isUseCustomNodeContent()) {
@@ -216,6 +217,7 @@ export default class TextEdit {
       rect,
       isInserting,
       isFromKeyDown,
+      isFromScale
     }
     if (this.mindMap.richText) {
       this.mindMap.richText.showEditText(params)

--- a/simple-mind-map/src/plugins/RichText.js
+++ b/simple-mind-map/src/plugins/RichText.js
@@ -188,7 +188,8 @@ class RichText {
       textAutoWrapWidth,
       selectTextOnEnterEditText,
       transformRichTextOnEnterEdit,
-      openRealtimeRenderOnNodeTextEdit
+      openRealtimeRenderOnNodeTextEdit,
+      enableAutoEmptyTextWhenKeydown
     } = this.mindMap.opt
     textAutoWrapWidth = node.hasCustomWidth()
       ? node.customTextWidth
@@ -287,6 +288,10 @@ class RichText {
     } else {
       // 已经是富文本
       this.textEditNode.innerHTML = this.cacheEditingText || nodeText
+    }
+    if (enableAutoEmptyTextWhenKeydown && isFromKeyDown) {
+      this.textEditNode.innerHTML = ''
+      this.lostStyle = true
     }
     this.initQuillEditor()
     document.querySelector('.ql-editor').style.minHeight = originHeight + 'px'


### PR DESCRIPTION
新增enableAutoEmptyTextWhenKeydown属性，允许单击节点后，键入时清空原文本，仅呈现键入的内容。目前钉钉、飞书都有这个功能。