### PR TITLE
feat: 解决缩放非整数时编辑浮层dom会出现锯齿问题

### DIFF
--- a/simple-mind-map/src/plugins/RichText.js
+++ b/simple-mind-map/src/plugins/RichText.js
@@ -229,6 +229,12 @@ class RichText {
         outline: none; 
         word-break: break-all;
         padding: ${paddingY}px ${paddingX}px;
+        // 强制使用gpu加速精确计算
+        transform-style: preserve-3d;
+        // 使用 filter 提高清晰度 在某些1080p屏幕下，字体模糊
+        filter: contrast(1) saturate(1);
+        // 3d下 渲染层优化
+        backface-visibility: hidden;
       `
       this.textEditNode.addEventListener('click', e => {
         e.stopPropagation()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f60f06c6-3f4b-47d9-bcf4-396ca366de76)

![image](https://github.com/user-attachments/assets/da330f3c-d6a8-4df7-81c2-6491fff3d16f)

transform: scale 是非整数时，在某些主题颜色下就会表现的比较明显，这个是经典的scale缩放精度渲染导致的锯齿问题，参考资料：

[CSS:使用缩放转换时的奇怪线条](https://cloud.tencent.cn/developer/information/CSS%3A%E4%BD%BF%E7%94%A8%E7%BC%A9%E6%94%BE%E8%BD%AC%E6%8D%A2%E6%97%B6%E7%9A%84%E5%A5%87%E6%80%AA%E7%BA%BF%E6%9D%A1)

[transform3d变化导致的字体模糊问题](https://juejin.cn/post/7066986698575446030)
