### PR TITLE
feat: 新增enableAutoEmptyTextWhenKeydown属性，单击节点键入清空原文本

### DIFF
--- a/simple-mind-map/src/constants/defaultOptions.js
+++ b/simple-mind-map/src/constants/defaultOptions.js
@@ -130,6 +130,8 @@ export const defaultOpt = {
   // 是否在存在一个激活节点时，当按下中文、英文、数字按键时自动进入文本编辑模式
   // 开启该特性后，需要给你的输入框绑定keydown事件，并禁止冒泡
   enableAutoEnterTextEditWhenKeydown: false,
+  // 是否在存在一个激活节点时，当按下中文、英文、数字按键时自动进入文本编辑模式，且节点文本清空
+  enableAutoEmptyTextWhenKeydown: false,
   // 自定义对剪贴板文本的处理。当按ctrl+v粘贴时会读取用户剪贴板中的文本和图片，默认只会判断文本是否是普通文本和simple-mind-map格式的节点数据，如果你想处理其他思维导图的数据，比如processon、zhixi等，那么可以传递一个函数，接受当前剪贴板中的文本为参数，返回处理后的数据，可以返回两种类型：
   /*
     1.返回一个纯文本，那么会直接以该文本创建一个子节点

--- a/simple-mind-map/src/core/render/TextEdit.js
+++ b/simple-mind-map/src/core/render/TextEdit.js
@@ -92,7 +92,8 @@ export default class TextEdit {
     })
     this.mindMap.on('scale', this.onScale)
     // // 监听按键事件，判断是否自动进入文本编辑模式
-    if (this.mindMap.opt.enableAutoEnterTextEditWhenKeydown) {
+    if (this.mindMap.opt.enableAutoEnterTextEditWhenKeydown ||
+      this.mindMap.opt.enableAutoEmptyTextWhenKeydown ) {
       window.addEventListener('keydown', this.onKeydown)
     }
     this.mindMap.on('beforeDestroy', () => {
@@ -115,10 +116,13 @@ export default class TextEdit {
       }
       if (
         opt.enableAutoEnterTextEditWhenKeydown !==
-        lastOpt.enableAutoEnterTextEditWhenKeydown
+        lastOpt.enableAutoEnterTextEditWhenKeydown ||
+        opt.enableAutoEmptyTextWhenKeydown !==
+        lastOpt.enableAutoEmptyTextWhenKeydown
       ) {
         window[
-          opt.enableAutoEnterTextEditWhenKeydown
+          opt.enableAutoEnterTextEditWhenKeydown ||
+          opt.enableAutoEmptyTextWhenKeydown
             ? 'addEventListener'
             : 'removeEventListener'
         ]('keydown', this.onKeydown)
@@ -265,7 +269,8 @@ export default class TextEdit {
       nodeTextEditZIndex,
       textAutoWrapWidth,
       selectTextOnEnterEditText,
-      openRealtimeRenderOnNodeTextEdit
+      openRealtimeRenderOnNodeTextEdit,
+      enableAutoEmptyTextWhenKeydown
     } = this.mindMap.opt
     if (!isFromScale) {
       this.mindMap.emit('before_show_text_edit')
@@ -339,6 +344,9 @@ export default class TextEdit {
     }
     this.textEditNode.style.zIndex = nodeTextEditZIndex
     this.textEditNode.innerHTML = textLines.join('<br>')
+    if (enableAutoEmptyTextWhenKeydown && isFromKeyDown) {
+      this.textEditNode.innerHTML = ''
+    }
     this.textEditNode.style.minWidth =
       rect.width + this.textNodePaddingX * 2 + 'px'
     this.textEditNode.style.minHeight = rect.height + 'px'

--- a/simple-mind-map/src/plugins/RichText.js
+++ b/simple-mind-map/src/plugins/RichText.js
@@ -188,7 +188,8 @@ class RichText {
       textAutoWrapWidth,
       selectTextOnEnterEditText,
       transformRichTextOnEnterEdit,
-      openRealtimeRenderOnNodeTextEdit
+      openRealtimeRenderOnNodeTextEdit,
+      enableAutoEmptyTextWhenKeydown
     } = this.mindMap.opt
     textAutoWrapWidth = node.hasCustomWidth()
       ? node.customTextWidth
@@ -287,6 +288,10 @@ class RichText {
     } else {
       // 已经是富文本
       this.textEditNode.innerHTML = this.cacheEditingText || nodeText
+    }
+    if (enableAutoEmptyTextWhenKeydown && isFromKeyDown) {
+      this.textEditNode.innerHTML = ''
+      this.lostStyle = true
     }
     this.initQuillEditor()
     document.querySelector('.ql-editor').style.minHeight = originHeight + 'px'


### PR DESCRIPTION
新增enableAutoEmptyTextWhenKeydown属性，允许单击节点后，键入时清空原文本，仅呈现键入的内容。目前钉钉、飞书都有这个功能。