### PR TITLE
fix： 限定富文本节点的编辑态格式类型 , 避免富文本节点编辑态下会触发渲染问题和结束编辑后的不一致问题，如有序列表（数字加点符号加空格触发）和无序列表（-符号加空格触发）

### DIFF
--- a/simple-mind-map/src/plugins/RichText.js
+++ b/simple-mind-map/src/plugins/RichText.js
@@ -473,6 +473,16 @@ class RichText {
           }
         }
       },
+      formats: [
+        'bold',
+        'italic',
+        'underline',
+        'strike',
+        'color',
+        'background',
+        'font',
+        'size'
+      ], // 明确指定允许的格式，不包含有序列表，无序列表等
       theme: 'snow'
     })
     // 拦截复制事件，即Ctrl + c，去除多余的空行


### PR DESCRIPTION
#984 

![image](https://github.com/user-attachments/assets/5f33f744-055d-4b40-b0e2-031359afdfc1)

修复后能支持这样的输入，否则编辑态输入触发后在节点内比较奇怪，结束输入后节点渲染又不支持该格式。脑图节点不需要支持富文本的有序列表和无序列表等功能，本身节点渲染也不支持。

