### PR TITLE
fix: 修复已设置了字体样式的节点，在清空后再输入文本，节点的字体样式变成了主题样式的bug

### DIFF
--- a/simple-mind-map/src/plugins/RichText.js
+++ b/simple-mind-map/src/plugins/RichText.js
@@ -540,8 +540,8 @@ class RichText {
       // 如果编辑过程中删除所有字符，那么会丢失主题的样式
       if (len <= 0 || (len === 1 && contents.ops[0].insert === '\n')) {
         this.lostStyle = true
-        // 需要删除节点的样式数据
-        this.syncFormatToNodeConfig(null, true)
+        // // 需要删除节点的样式数据
+        // this.syncFormatToNodeConfig(null, true)
       } else if (this.lostStyle && !this.isCompositing) {
         // 如果处于样式丢失状态，那么需要进行格式化加回样式
         this.setTextStyleIfNotRichText(this.node)


### PR DESCRIPTION
节点设置了字体样式后，清空节点文本再输入新文本，发现字体样式丢失，变成了主题样式，希望保留已设置的字体样式。