### PR TITLE
fix: 解决切换主题前后，设置了部分字体样式的节点，其未设置的字体样式没有响应新主题样式的bug

### DIFF
--- a/simple-mind-map/src/core/render/node/Style.js
+++ b/simple-mind-map/src/core/render/node/Style.js
@@ -192,14 +192,15 @@ class Style {
   }
 
   // 生成内联样式
-  createStyleText() {
+  createStyleText(customStyle) {
     const styles = {
       color: this.merge('color'),
       fontFamily: this.merge('fontFamily'),
       fontSize: this.merge('fontSize'),
       fontWeight: this.merge('fontWeight'),
       fontStyle: this.merge('fontStyle'),
-      textDecoration: this.merge('textDecoration')
+      textDecoration: this.merge('textDecoration'),
+      ...customStyle
     }
     return `
       color: ${styles.color};
@@ -352,6 +353,17 @@ class Style {
       }
     })
     return res
+  }
+
+  // 获取自定义的样式
+  getCustomStyle() {
+    let customStyle = {}
+    Object.keys(this.ctx.getData()).forEach(item => {
+      if (checkIsNodeStyleDataKey(item)) {
+        customStyle[item] = this.ctx.getData(item)
+      }
+    })
+    return customStyle
   }
 
   // hover和激活节点

--- a/simple-mind-map/src/core/render/node/nodeCreateContents.js
+++ b/simple-mind-map/src/core/render/node/nodeCreateContents.js
@@ -139,16 +139,18 @@ function createRichTextNode(specifyText) {
     recoverText = true
   }
   if ([CONSTANTS.CHANGE_THEME].includes(this.mindMap.renderer.renderSource)) {
-    // 如果自定义过样式则不允许覆盖
-    if (!this.hasCustomStyle()) {
+    // // 如果自定义过样式则不允许覆盖
+    // if (!this.hasCustomStyle() ) {
       recoverText = true
-    }
+    // }
   }
   if (recoverText && !isUndef(text)) {
     // 判断节点内容是否是富文本
     let isRichText = checkIsRichText(text)
+    // 获取自定义样式
+    let customStyle = this.getCustomStyle()
     // 样式字符串
-    let style = this.style.createStyleText()
+    let style = this.style.createStyleText(customStyle)
     if (isRichText) {
       // 如果是富文本那么线移除内联样式
       text = removeHtmlStyle(text)
@@ -158,6 +160,14 @@ function createRichTextNode(specifyText) {
       // 给span添加样式没有成功，则尝试给strong标签添加样式
       if (text === _text) {
         text = addHtmlStyle(text, 'strong', style)
+      }
+      // 给strong添加样式没有成功，则尝试给s标签添加样式
+      if (text === _text) {
+        text = addHtmlStyle(text, 's', style)
+      }
+      // 给s添加样式没有成功，则尝试给em标签添加样式
+      if (text === _text) {
+        text = addHtmlStyle(text, 'em', style)
       }
     } else {
       // 非富文本


### PR DESCRIPTION
背景：字体样式包括字体、颜色、大小、粗体、斜体、下划线等

现状：设置某节点的部分字体样式，然后切换主题，发现该节点变为自定义节点，所有字体样式都无法响应新主题的样式
举例：设置node1为粗体，然后切换主题，node1的粗体有保留，但字体、颜色、大小、斜体、下划线都没变成新主题的样式，继续沿用旧主题的样式

期望：设置某节点的部分字体样式，然后切换主题，其未设置的字体样式可以响应新主题样式
期望举例：设置node1为粗体，然后切换主题，node1的粗体保留，字体颜色能响应新主题的字体颜色，其余字体样式同理

市场调研：目前钉钉能够做到已设置的字体样式，在切换主题后，已设置的字体样式继续保留，且字体颜色跟随主题色变动