### PR TITLE
fix: 修复safari导出问题

### DIFF
--- a/simple-mind-map/src/plugins/Export.js
+++ b/simple-mind-map/src/plugins/Export.js
@@ -289,7 +289,17 @@ class Export {
     this.handleNodeExport(node)
     const { str, clipData } = await this.getSvgData(node)
     const svgUrl = await this.fixSvgStrAndToBlob(str)
-    const res = await this.svgToPng(svgUrl, transparent, clipData)
+    const isSafari = () => {
+      return (
+        navigator.userAgent.includes('Safari') &&
+        !navigator.userAgent.includes('Chrome')
+      )
+    }
+    let res
+    res = await this.svgToPng(svgUrl, transparent, clipData)
+    if (isSafari()) {
+      res = await this.svgToPng(svgUrl, transparent, clipData)
+    }
     return res
   }
 


### PR DESCRIPTION
safari环境下，最后一步canvas drawImg第一次执行节点图片转换不完全，再执行一遍就可以了，目前这个方法验证是可行的，多执行一遍最后一步耗时不会增加多少