### PR TITLE
feat(ui): Add toggle button for associative line visibility

### DIFF
--- a/simple-mind-map/src/plugins/AssociativeLine.js
+++ b/simple-mind-map/src/plugins/AssociativeLine.js
@@ -758,6 +758,47 @@ class AssociativeLine {
     this.mindMap.deleteEditNodeClass(ASSOCIATIVE_LINE_TEXT_EDIT_WRAP)
     this.unBindEvent()
   }
+
+  // Toggle visibility of all associative lines
+  // Returns the new visibility state (true = visible, false = hidden)
+  toggleAllLinesVisibility() {
+    if (this._linesHidden) {
+      this.showAllLines()
+      return true
+    } else {
+      this.hideAllLines()
+      return false
+    }
+  }
+
+  // Hide all associative lines and their labels
+  hideAllLines() {
+    this._linesHidden = true
+    this.lineList.forEach(line => {
+      line[0].hide() // path
+      line[1].hide() // clickPath
+      line[2].hide() // text
+    })
+    this.hideControls()
+    this.mindMap.emit('associative_line_visibility_change', false)
+  }
+
+  // Show all associative lines and their labels
+  showAllLines() {
+    this._linesHidden = false
+    this.lineList.forEach(line => {
+      line[0].show() // path
+      line[1].show() // clickPath
+      line[2].show() // text
+    })
+    this.showControls()
+    this.mindMap.emit('associative_line_visibility_change', true)
+  }
+
+  // Get current visibility state
+  getLinesVisibility() {
+    return !this._linesHidden
+  }
 }
 
 AssociativeLine.instanceName = 'associativeLine'

--- a/web/src/lang/en_us.js
+++ b/web/src/lang/en_us.js
@@ -216,7 +216,9 @@ export default {
     downloadClient: 'Download client',
     site: 'Official website',
     current: 'Current:',
-    downloadDesc: 'You can download it from the following address:'
+    downloadDesc: 'You can download it from the following address:',
+    showAssociativeLines: 'Show associative lines',
+    hideAssociativeLines: 'Hide associative lines'
   },
   nodeHyperlink: {
     title: 'Link',

--- a/web/src/lang/zh_cn.js
+++ b/web/src/lang/zh_cn.js
@@ -210,7 +210,9 @@ export default {
     downloadClient: '下载客户端',
     site: '官方网站',
     current: '当前：',
-    downloadDesc: '可从如下地址下载：'
+    downloadDesc: '可从如下地址下载：',
+    showAssociativeLines: '显示关联线',
+    hideAssociativeLines: '隐藏关联线'
   },
   nodeHyperlink: {
     title: '超链接',

--- a/web/src/pages/Edit/components/NavigatorToolbar.vue
+++ b/web/src/pages/Edit/components/NavigatorToolbar.vue
@@ -44,6 +44,23 @@
       </el-tooltip>
     </div>
     <div class="item">
+      <el-tooltip
+        effect="dark"
+        :content="
+          showAssociativeLines
+            ? $t('navigatorToolbar.hideAssociativeLines')
+            : $t('navigatorToolbar.showAssociativeLines')
+        "
+        placement="top"
+      >
+        <div 
+          class="btn iconfont iconlianjiexian" 
+          :style="{ opacity: showAssociativeLines ? 1 : 0.4 }"
+          @click="toggleAssociativeLines"
+        ></div>
+      </el-tooltip>
+    </div>
+    <div class="item">
       <!-- <el-switch
         v-model="isReadonly"
         :active-text="$t('navigatorToolbar.readonly')"
@@ -156,7 +173,8 @@ export default {
       version: pkg.version,
       langList,
       lang: '',
-      openMiniMap: false
+      openMiniMap: false,
+      showAssociativeLines: true
     }
   },
   computed: {
@@ -243,6 +261,12 @@ export default {
       a.href = url
       a.target = '_blank'
       a.click()
+    },
+
+    toggleAssociativeLines() {
+      if (this.mindMap && this.mindMap.associativeLine) {
+        this.showAssociativeLines = this.mindMap.associativeLine.toggleAllLinesVisibility()
+      }
     },
 
     backToRoot() {


### PR DESCRIPTION
## Summary

- Adds a toolbar button to show/hide all associative lines with a single click
- Useful for complex mind maps where associative lines may clutter the view
- Button displays with reduced opacity (0.4) when lines are hidden

## Changes

**simple-mind-map/src/plugins/AssociativeLine.js:**
- Added `toggleAllLinesVisibility()` - toggles visibility and returns new state
- Added `hideAllLines()` - hides all lines and emits event
- Added `showAllLines()` - shows all lines and emits event
- Added `getLinesVisibility()` - returns current visibility state
- Emits `associative_line_visibility_change` event on toggle

**web/src/pages/Edit/components/NavigatorToolbar.vue:**
- Added toggle button with `iconlianjiexian` icon
- Button placed after mini-map toggle
- Tooltip shows "Show/Hide associative lines" based on state

**web/src/lang/en_us.js, zh_cn.js:**
- Added `showAssociativeLines` and `hideAssociativeLines` translations

## Test plan

1. Open a mind map with associative lines
2. Click the new toggle button in the bottom toolbar
3. Verify all associative lines disappear
4. Click again to verify lines reappear
5. Verify tooltip text changes appropriately

Made with [Cursor](https://cursor.com)